### PR TITLE
Feature/cake upgrade

### DIFF
--- a/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
+++ b/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.0" />
-    <PackageReference Include="Cake.Testing" Version="0.22.0" />
+    <PackageReference Include="Cake.Core" Version="0.26.1" />
+    <PackageReference Include="Cake.Testing" Version="0.26.1" />
     <PackageReference Include="YamlDotNet" version="4.2.1" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />

--- a/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
+++ b/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,6 +27,10 @@
     <None Update="TestMerge.Yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/src/Cake.Yaml/Cake.Yaml.csproj
+++ b/src/Cake.Yaml/Cake.Yaml.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.0" />
+    <PackageReference Include="Cake.Core" Version="0.26.1" />
     <PackageReference Include="YamlDotNet" Version="4.2.1" />
   </ItemGroup>
 

--- a/src/Cake.Yaml/Cake.Yaml.csproj
+++ b/src/Cake.Yaml/Cake.Yaml.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
Upgraded netstandards target version to 2.0 to match Cake build target. 

Upgraded Cake packages to latest stable 0.26.1