### PR TITLE
Update Cake to version 0.28.0

### DIFF
--- a/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
+++ b/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.26.0" />
-    <PackageReference Include="Cake.Testing" Version="0.26.0" />
+    <PackageReference Include="Cake.Core" Version="0.28.0" />
+    <PackageReference Include="Cake.Testing" Version="0.28.0" />
     <PackageReference Include="YamlDotNet" version="5.2.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/Cake.Yaml.Tests/FakeContext.cs
+++ b/src/Cake.Yaml.Tests/FakeContext.cs
@@ -13,6 +13,18 @@ namespace Cake.Yaml.Tests
         FakeLog log;
         DirectoryPath testsDir;
 
+        private class FakeDataResolver : ICakeDataService
+        {
+            public void Add<TData>(TData value) where TData : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public TData Get<TData>() where TData : class
+            {
+                throw new NotImplementedException();
+            }
+        }
 
         public FakeCakeContext ()
         {
@@ -28,7 +40,8 @@ namespace Cake.Yaml.Tests
             var registry = new WindowsRegistry ();
 
             var toolLocator = new ToolLocator(environment, new ToolRepository(environment), new ToolResolutionStrategy(fileSystem, environment, globber, new FakeConfiguration()));
-            context = new CakeContext(fileSystem, environment, globber, log, args, processRunner, registry, toolLocator);
+            var dataService = new FakeDataResolver(); 
+            context = new CakeContext(fileSystem, environment, globber, log, args, processRunner, registry, toolLocator, dataService);
             context.Environment.WorkingDirectory = testsDir;
         }
 

--- a/src/Cake.Yaml/Cake.Yaml.csproj
+++ b/src/Cake.Yaml/Cake.Yaml.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.26.0" />
+    <PackageReference Include="Cake.Core" Version="0.28.0" />
     <PackageReference Include="YamlDotNet" Version="5.2.1" />
   </ItemGroup>
  


### PR DESCRIPTION
This PR updates the Cake dependencies to latest version, avoiding to skip the validation if the user is using the latest version.

Part of #9 