### PR TITLE
Update YamlDotNet to fix security vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ You can easily reference Cake.Yaml directly in your build script via a cake addi
 
 ```csharp
 #addin nuget:?package=Cake.Yaml
-#addin nuget:?package=YamlDotNet&version=4.2.1
+#addin nuget:?package=YamlDotNet&version=5.2.1
 ```
 
-NOTE: It's very important at this point in time to specify the `YamlDotNet` package *and* the version _4.2.1_ for it.
+NOTE: It's very important at this point in time to specify the `YamlDotNet` package *and* the version _5.2.1_ for it.
 
 ## Aliases
 

--- a/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
+++ b/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.26.0" />
     <PackageReference Include="Cake.Testing" Version="0.26.0" />
-    <PackageReference Include="YamlDotNet" version="4.2.1" />
+    <PackageReference Include="YamlDotNet" version="5.2.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />

--- a/src/Cake.Yaml/Cake.Yaml.csproj
+++ b/src/Cake.Yaml/Cake.Yaml.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.26.0" />
-    <PackageReference Include="YamlDotNet" Version="4.2.1" />
+    <PackageReference Include="YamlDotNet" Version="5.2.1" />
   </ItemGroup>
  
 </Project>


### PR DESCRIPTION
YamlDotNet < 5.0 is vulnerably by [this issue](https://nvd.nist.gov/vuln/detail/CVE-2018-1000210).

Update YamlDotNet to fix the security vulnerability.