### PR TITLE
Added cake-addin tag. Closes #21

### DIFF
--- a/src/Cake.Yaml/Cake.Yaml.csproj
+++ b/src/Cake.Yaml/Cake.Yaml.csproj
@@ -10,7 +10,7 @@
     <Title>Cake.Yaml</Title>
     <Summary>YAML Serialization addon for cake build.</Summary>
     <Description>Cake Build addon for YAML Serialization.</Description>
-    <PackageTags>Cake Script Build YAML</PackageTags>
+    <PackageTags>cake;script;build;cake-addin;YAML</PackageTags>
     <Authors>Redth</Authors>
     <Owners>Redth,cake-contrib</Owners>
     <PackageProjectUrl>https://github.com/cake-contrib/Cake.Yaml</PackageProjectUrl>


### PR DESCRIPTION
## Description
Added the cake-addin tag to the nuget package 

## Related Issue
#21 

## Motivation and Context
It was required to get the cake-tab in nuget.org to show the correct information.

## How Has This Been Tested?
.\build.ps1 --verbosity=Diagnostic
It builds the same way as before (no changes in the build output), but the nuget package now contains the "cake-addin" tag.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
