### PR TITLE
Feature/upgrade to cake 1.0.0 (closes #29)

### DIFF
--- a/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
+++ b/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="1.0.0" />
-    <PackageReference Include="Cake.Testing" Version="0.33.0" />
+    <PackageReference Include="Cake.Testing" Version="1.0.0" />
     <PackageReference Include="YamlDotNet" version="6.1.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
+++ b/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.33.0" />
+    <PackageReference Include="Cake.Core" Version="1.0.0" />
     <PackageReference Include="Cake.Testing" Version="0.33.0" />
     <PackageReference Include="YamlDotNet" version="6.1.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Cake.Yaml.Tests/FakeCakeArguments.cs
+++ b/src/Cake.Yaml.Tests/FakeCakeArguments.cs
@@ -6,34 +6,31 @@ namespace Cake.Yaml.Tests
 {
     internal sealed class FakeCakeArguments : ICakeArguments
     {
-        private readonly Dictionary<string, string> _arguments;
+        private readonly Dictionary<string, List<string>> _arguments;
 
         /// <summary>
         /// Gets the arguments.
         /// </summary>
         /// <value>The arguments.</value>
-        public IReadOnlyDictionary<string, string> Arguments
-        {
-            get { return _arguments; }
-        }
+        public IReadOnlyDictionary<string, List<string>> Arguments => _arguments;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CakeArguments"/> class.
         /// </summary>
         public FakeCakeArguments()
         {
-            _arguments = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            _arguments = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
         /// Initializes the argument list.
         /// </summary>
         /// <param name="arguments">The arguments.</param>
-        public void SetArguments(IDictionary<string, string> arguments)
+        public void SetArguments(IDictionary<string, List<string>> arguments)
         {
             if (arguments == null)
             {
-                throw new ArgumentNullException("arguments");
+                throw new ArgumentNullException(nameof(arguments));
             }
             _arguments.Clear();
             foreach (var argument in arguments)
@@ -58,11 +55,12 @@ namespace Cake.Yaml.Tests
         /// Gets an argument.
         /// </summary>
         /// <param name="name">The argument name.</param>
-        /// <returns>The argument value.</returns>
-        public string GetArgument(string name)
+        /// <returns>The argument values.</returns>
+        public ICollection<string> GetArguments(string name)
         {
-            return _arguments.ContainsKey(name)
-                ? _arguments[name] : null;
+            _arguments.TryGetValue(name, out List<string> value);
+            ICollection<string> collection = value;
+            return collection ?? Array.Empty<string>();
         }
     }
 }

--- a/src/Cake.Yaml.Tests/FakeContext.cs
+++ b/src/Cake.Yaml.Tests/FakeContext.cs
@@ -38,7 +38,7 @@ namespace Cake.Yaml.Tests
             var args = new FakeCakeArguments ();
             var registry = new WindowsRegistry ();
             var config = new Core.Configuration.CakeConfigurationProvider(fileSystem, environment).CreateConfiguration(testsDir, new Dictionary<string, string>());
-            var toolLocator = new ToolLocator(environment, new ToolRepository(environment), new ToolResolutionStrategy(fileSystem, environment, globber, new FakeConfiguration()));
+            var toolLocator = new ToolLocator(environment, new ToolRepository(environment), new ToolResolutionStrategy(fileSystem, environment, globber, new FakeConfiguration(), log));
             var processRunner = new ProcessRunner(fileSystem, environment, log, toolLocator, config);
             var dataService = new FakeDataResolver(); 
             context = new CakeContext(fileSystem, environment, globber, log, args, processRunner, registry, toolLocator, dataService, config);

--- a/src/Cake.Yaml/Cake.Yaml.csproj
+++ b/src/Cake.Yaml/Cake.Yaml.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <None Include="images/icon.png" Pack="true" PackagePath="images"/>
-    <PackageReference Include="Cake.Core" Version="0.33.0">
+    <PackageReference Include="Cake.Core" Version="1.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="YamlDotNet" Version="6.1.2" />


### PR DESCRIPTION
Upgraded to reference Cake.Core 1.0.0

## Description
Upgraded to reference Cake.Core 1.0.0 and Cake.Testing 1.0.0
Updated FakeCakeArguments to support value as List<string> instead of just string.
Updated FakeContext so the ToolResolutionStrategy gets the now required log.

## Related Issue
Issue #29 

## Motivation and Context
Wanted to help, as I'm using this library myself.

## How Has This Been Tested?
- The build runs ok with all the tests green.
- I changed my own build to use the new version using #addin "nuget:file:///C:/MyFeed/?package=Cake.Yaml&prerelease"
- The new version from file doesn't render the warning about version 0.33.0 of Cake.Core anymore.
- Script worked as it used to. Both serialize and deserialize renders the same result as before.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
