### PR TITLE
Fix unit tests - Closes #37

### DIFF
--- a/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
+++ b/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="YamlDotNet" version="6.1.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
+++ b/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
+++ b/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
@@ -9,7 +9,10 @@
     <PackageReference Include="Cake.Testing" Version="1.0.0" />
     <PackageReference Include="YamlDotNet" version="6.1.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
   </ItemGroup>
 

--- a/src/Cake.Yaml.Tests/Test.cs
+++ b/src/Cake.Yaml.Tests/Test.cs
@@ -86,7 +86,7 @@ namespace Cake.Yaml.Tests
 
             AssertDictionaryMatchesTestMergeYaml(testObjectDictionary);
         }
-        public void AssertDictionaryMatchesTestMergeYaml(Dictionary<string, TestMergeObject> testDictionary)
+        private void AssertDictionaryMatchesTestMergeYaml(Dictionary<string, TestMergeObject> testDictionary)
         {
             Assert.Equal(3, testDictionary.Count);
             Assert.Equal("item1", testDictionary["default"].Item1);


### PR DESCRIPTION
## Description
- Removed dotnetapp2.0 from TargetFramework
- Added dotnetapp3.1 and net5.0 to TargetFrameworks
- Updated Microsoft.NET.Test.Sdk nuget to latest version
- Updated xunit.runner.visualstudio nuget to latest version
- Made the method "AssertDictionaryMatchesTestMergeYaml" private to fix the xUnit1013 warnings.

## Related Issue
Issue #37 

## Motivation and Context
Made the build run on a clean installed computer with only VisualStudio 2019 version 16.10 installed and remove the unit test build warnings.

## How Has This Been Tested?
Tested running the builds locally on my computer.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
