### PR TITLE
Add support for YamlDotNet naming conventions

### DIFF
--- a/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
+++ b/src/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
@@ -24,6 +24,9 @@
     <None Update="serialized.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="test_camelcase.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="test.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Cake.Yaml.Tests/test_camelcase.yaml
+++ b/src/Cake.Yaml.Tests/test_camelcase.yaml
@@ -1,0 +1,18 @@
+﻿name: Testing
+items:
+- One
+- Two
+- Three
+keysAndValues:
+  Key: Value
+  AnotherKey: AnotherValue
+  Such: Wow
+nested:
+  value: 7
+multiples:
+- id: 1
+  value: 14
+- id: 2
+  value: 29
+- id: 3
+  value: 58

--- a/src/Cake.Yaml/DeserializeYamlSettings.cs
+++ b/src/Cake.Yaml/DeserializeYamlSettings.cs
@@ -1,0 +1,13 @@
+﻿namespace Cake.Yaml
+{
+    /// <summary>
+    /// Contains settings for YAML deserialization using <see cref="YamlAliases"/>.
+    /// </summary>
+    public sealed class DeserializeYamlSettings : YamlSettings
+    {
+        /// <summary>
+        /// The default <see cref="DeserializeYamlSettings"/>.
+        /// </summary>
+        public static DeserializeYamlSettings Default { get; set; } = new DeserializeYamlSettings();
+    }
+}

--- a/src/Cake.Yaml/SerializeYamlSettings.cs
+++ b/src/Cake.Yaml/SerializeYamlSettings.cs
@@ -1,0 +1,13 @@
+﻿namespace Cake.Yaml
+{
+    /// <summary>
+    /// Contains settings for YAML serialization using <see cref="YamlAliases"/>.
+    /// </summary>
+    public sealed class SerializeYamlSettings : YamlSettings
+    {
+        /// <summary>
+        /// The default <see cref="SerializeYamlSettings"/>.
+        /// </summary>
+        public static SerializeYamlSettings Default { get; set; } = new SerializeYamlSettings();
+    }
+}

--- a/src/Cake.Yaml/YamlAliases.cs
+++ b/src/Cake.Yaml/YamlAliases.cs
@@ -1,9 +1,11 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Annotations;
 using YamlDotNet.Core;
+using YamlDotNet.Serialization;
 
 namespace Cake.Yaml
 {
@@ -19,6 +21,8 @@ namespace Cake.Yaml
     /// </para>
     /// </summary>
     [CakeAliasCategory("Yaml")]
+    [CakeNamespaceImport("Cake.Yaml")]
+    [CakeNamespaceImport("YamlDotNet.Serialization.NamingConventions")]
     public static class YamlAliases
     {
         /// <summary>
@@ -29,12 +33,25 @@ namespace Cake.Yaml
         /// <param name="filename">The YAML filename.</param>
         /// <typeparam name="T">The type to deserialize to.</typeparam>
         [CakeMethodAlias]
-        //[CakeNamespaceImport("YamlDotNet")]
         public static T DeserializeYamlFromFile<T>(this ICakeContext context, FilePath filename)
+        {
+            return DeserializeYamlFromFile<T>(context, filename, DeserializeYamlSettings.Default);
+        }
+
+        /// <summary>
+        /// Deserializes the YAML from a file.
+        /// </summary>
+        /// <returns>The Deserialized Object.</returns>
+        /// <param name="context">The context.</param>
+        /// <param name="filename">The YAML filename.</param>
+        /// <param name="settings">The <see cref="DeserializeYamlSettings"/> that will be used to build the deserializer.</param>
+        /// <typeparam name="T">The type to deserialize to.</typeparam>
+        [CakeMethodAlias]
+        public static T DeserializeYamlFromFile<T>(this ICakeContext context, FilePath filename, DeserializeYamlSettings settings)
         {
             T result = default(T);
 
-            var d = new YamlDotNet.Serialization.Deserializer();
+            var d = BuildDeserializer(settings);
 
             using (var tr = File.OpenText(filename.MakeAbsolute(context.Environment).FullPath))
             {
@@ -53,17 +70,31 @@ namespace Cake.Yaml
         /// <param name="yaml">The YAML string.</param>
         /// <typeparam name="T">The type to deserialize to.</typeparam>
         [CakeMethodAlias]
-        //[CakeNamespaceImport("YamlDotNet")]
-        public static T DeserializeYaml<T> (this ICakeContext context, string yaml)
+        public static T DeserializeYaml<T>(this ICakeContext context, string yaml)
+        {
+            return DeserializeYaml<T>(context, yaml, DeserializeYamlSettings.Default);
+        }
+
+        /// <summary>
+        /// Deserializes the YAML from a string.
+        /// </summary>
+        /// <returns>The Deserialized Object.</returns>
+        /// <param name="context">The context.</param>
+        /// <param name="yaml">The YAML string.</param>
+        /// <param name="settings">The <see cref="DeserializeYamlSettings"/> that will be used to build the deserializer.</param>
+        /// <typeparam name="T">The type to deserialize to.</typeparam>
+        [CakeMethodAlias]
+        public static T DeserializeYaml<T>(this ICakeContext context, string yaml, DeserializeYamlSettings settings)
         {
             T result = default(T);
 
-            var d = new YamlDotNet.Serialization.Deserializer ();
+            var d = BuildDeserializer(settings);
             using (var tr = new StringReader(yaml))
             {
                 var reader = new MergingParser(new Parser(tr));
                 result = d.Deserialize<T>(reader);
             }
+
             return result;
         }
 
@@ -75,13 +106,33 @@ namespace Cake.Yaml
         /// <param name="instance">The object to serialize.</param>
         /// <typeparam name="T">The type of object to serialize.</typeparam>
         [CakeMethodAlias]
-        //[CakeNamespaceImport("YamlDotNet")]
-        public static void SerializeYamlToFile<T> (this ICakeContext context, FilePath filename, T instance)
+        public static void SerializeYamlToFile<T>(this ICakeContext context, FilePath filename, T instance)
         {
-            var s = new YamlDotNet.Serialization.Serializer ();
+            SerializeYamlToFile(context, filename, instance, SerializeYamlSettings.Default);
+        }
+
+        /// <summary>
+        /// Serializes an object to a YAML file.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="filename">The filename to serialize to.</param>
+        /// <param name="instance">The object to serialize.</param>
+        /// <param name="settings">The <see cref="SerializeYamlSettings"/> that will be used to build the serializer.</param>
+        /// <typeparam name="T">The type of object to serialize.</typeparam>
+        [CakeMethodAlias]
+        public static void SerializeYamlToFile<T>(this ICakeContext context, FilePath filename, T instance, SerializeYamlSettings settings)
+        {
+            if (settings is null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            var s = BuildSerializer(settings);
 
             using (var tw = new StreamWriter(File.Open(filename.MakeAbsolute(context.Environment).FullPath, FileMode.Create)))
+            {
                 s.Serialize(tw, instance);
+            }
         }
 
         /// <summary>
@@ -92,17 +143,62 @@ namespace Cake.Yaml
         /// <param name="instance">The object to serialize.</param>
         /// <typeparam name="T">The type of object to serialize.</typeparam>
         [CakeMethodAlias]
-        //[CakeNamespaceImport("YamlDotNet")]
-        public static string SerializeYaml<T> (this ICakeContext context, T instance)
+        public static string SerializeYaml<T>(this ICakeContext context, T instance)
         {
-            var s = new YamlDotNet.Serialization.Serializer ();
+            return SerializeYaml(context, instance, SerializeYamlSettings.Default);
+        }
 
-            var sb = new StringBuilder ();
-            using (var tw = new StringWriter (sb))
-                s.Serialize (tw, instance);
+        /// <summary>
+        /// Serializes an object to a YAML string.
+        /// </summary>
+        /// <returns>The YAML string.</returns>
+        /// <param name="context">The context.</param>
+        /// <param name="instance">The object to serialize.</param>
+        /// <param name="settings">The <see cref="SerializeYamlSettings"/> that will be used to build the serializer.</param>
+        /// <typeparam name="T">The type of object to serialize.</typeparam>
+        [CakeMethodAlias]
+        public static string SerializeYaml<T>(this ICakeContext context, T instance, SerializeYamlSettings settings)
+        {
+            if (settings is null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
 
-            return sb.ToString ();
+            var s = BuildSerializer(settings);
+
+            var sb = new StringBuilder();
+            using (var tw = new StringWriter(sb))
+            {
+                s.Serialize(tw, instance);
+            }
+
+            return sb.ToString();
+        }
+
+        private static ISerializer BuildSerializer(SerializeYamlSettings settings)
+        {
+            var serializerBuilder = new SerializerBuilder();
+
+            if (!(settings.NamingConvention is null))
+            {
+                serializerBuilder = serializerBuilder.WithNamingConvention(settings.NamingConvention);
+            }
+
+            var serializer = serializerBuilder.Build();
+            return serializer;
+        }
+
+        private static IDeserializer BuildDeserializer(DeserializeYamlSettings settings)
+        {
+            var deserializerBuilder = new DeserializerBuilder();
+
+            if (!(settings.NamingConvention is null))
+            {
+                deserializerBuilder = deserializerBuilder.WithNamingConvention(settings.NamingConvention);
+            }
+
+            var deserializer = deserializerBuilder.Build();
+            return deserializer;
         }
     }
 }
-

--- a/src/Cake.Yaml/YamlSettings.cs
+++ b/src/Cake.Yaml/YamlSettings.cs
@@ -1,0 +1,15 @@
+﻿using YamlDotNet.Serialization;
+
+namespace Cake.Yaml
+{
+    /// <summary>
+    /// Base class for settings for YAML serialization and deserialization using <see cref="YamlAliases"/>.
+    /// </summary>
+    public abstract class YamlSettings
+    {
+        /// <summary>
+        /// The <see cref="INamingConvention"/> that will be used by the (de)serializer.
+        /// </summary>
+        public INamingConvention NamingConvention { get; set; }
+    }
+}


### PR DESCRIPTION
Add support for YamlDotNet naming conventions for serialization and deserialization.

e.g.

```cakescript
#addin nuget:?package=Cake.Yaml&version=5.0.0
#addin nuget:?package=YamlDotNet&version=11.2.1

var settings = new SerializeYamlSettings
{
    NamingConvention = CamelCaseNamingConvention.Instance,
};

var serialized = SerializeYaml(someObject, settings);
```

---

Closes #5
